### PR TITLE
修改关键字和描述的取值方式

### DIFF
--- a/journals.ftl
+++ b/journals.ftl
@@ -63,12 +63,14 @@
                                         </li>
                                     </#if>
                                 </#list>
-                                <li class="pagination-next<#if pagination.hasNext><#else > is-invisible </#if>">
-                                    <a class="pagination-circle" href="${pagination.nextPageFullPath!}">
-                                        <#--            <#include "icon/arrow-right.ftl">-->
-                                        <span class="cst-icon icon-next"> </span>
-                                    </a>
-                                </li>
+                                <#if pagination.hasNext>
+                                    <li class="pagination-next is-invisible">
+                                        <a class="pagination-circle" href="${pagination.nextPageFullPath!}">
+                                            <#--            <#include "icon/arrow-right.ftl">-->
+                                            <span class="cst-icon icon-next"> </span>
+                                        </a>
+                                    </li>
+                                </#if>
                             </ul>
                         </@paginationTag>
                     </#if>

--- a/journals.ftl
+++ b/journals.ftl
@@ -64,7 +64,7 @@
                                     </#if>
                                 </#list>
                                 <#if pagination.hasNext>
-                                    <li class="pagination-next is-invisible">
+                                    <li class="pagination-next">
                                         <a class="pagination-circle" href="${pagination.nextPageFullPath!}">
                                             <#--            <#include "icon/arrow-right.ftl">-->
                                             <span class="cst-icon icon-next"> </span>

--- a/module/pagination.ftl
+++ b/module/pagination.ftl
@@ -16,7 +16,7 @@
         </#if>
     </#list>
     <#if pagination.hasNext>
-        <li class="pagination-next is-invisible">
+        <li class="pagination-next">
             <a class="pagination-circle" href="${pagination.nextPageFullPath!}">
                 <span class="iconfont icon-right-fill"> </span>
             </a>

--- a/module/pagination.ftl
+++ b/module/pagination.ftl
@@ -15,9 +15,11 @@
             </li>
         </#if>
     </#list>
-    <li class="pagination-next<#if pagination.hasNext><#else > is-invisible </#if>">
-        <a class="pagination-circle" href="${pagination.nextPageFullPath!}">
-            <span class="iconfont icon-right-fill"> </span>
-        </a>
-    </li>
+    <#if pagination.hasNext>
+        <li class="pagination-next is-invisible">
+            <a class="pagination-circle" href="${pagination.nextPageFullPath!}">
+                <span class="iconfont icon-right-fill"> </span>
+            </a>
+        </li>
+    </#if>
 </ul>

--- a/post.ftl
+++ b/post.ftl
@@ -1,5 +1,5 @@
 <#include "module/macro.ftl">
-<@layout title="${post.title!} | ${options.blog_title!} " keywords="${options.seo_keywords!}" description="${options.seo_description!}">
+<@layout title="${post.title!} | ${options.blog_title!} " keywords="${meta_keywords!}" description="${meta_description!}">
     <main class="mx-auto" id="container">
         <header class="bg-cover post-cover" id="postHeader">
             <#if post.thumbnail?? && post.thumbnail!=''>

--- a/post.ftl
+++ b/post.ftl
@@ -21,7 +21,11 @@
                                  src="${user.avatar!}" alt=""/>
                             <span class="post-author">${post.visits} 次访问</span>
                             <time class="published"
-                                  datetime="${post.createTime?string("yyyy-MM-dd")}">${post.createTime?string("yyyy-MM-dd")}</time>
+                                  datetime="${post.createTime?string("yyyy-MM-dd")}">发布: ${post.createTime?string("yyyy-MM-dd")}</time>
+                            <#if "${post.createTime}" != "${post.editTime}">
+                                <time class="published"
+                                      datetime="${post.editTime?string("yyyy-MM-dd")}">最后编辑: ${post.editTime?string("yyyy-MM-dd")}</time>
+                            </#if>
                         </div>
                         <div class="text-center post-categories">
                             <#if post.categories?? && post.categories?size gt 0>


### PR DESCRIPTION
之前的取值方式，是取的 `博客后台设置-》seo设置` 中的主页关键字和描述

但是每篇文章的 `设置->高级设置` 单独指定这篇文字的关键字和描述

用现在的方式取，才能取到每篇文章对应的关键字和描述

> 我发现搜索引擎中我博客的每一篇文章都是一样的描述，然后看了下主题源码，发现这个问题。。。

halo 主题开发文档如下：

**页面关键词**
```
${meta_keywords!}
```
需要注意的是，虽然这个变量在任何页面都可以使用，但是其值可能在不同的页面是不一样的。会根据用户的设置，生成对应的值。

假设在文章页面：
- 如果用户为文章设置了标签，而没有设置 自定义关键词，系统会自动将标签设置为页面关键词。
- 如果用户设置了 自定义关键词，那么则会取用户设置的值。

**页面描述**
```
${meta_description!}
```
需要注意的是，虽然这个变量在任何页面都可以使用，但是其值可能在不同的页面是不一样的。会根据用户的设置，生成对应的值。