### PR TITLE
适应浏览器安全策略

### DIFF
--- a/module/script.ftl
+++ b/module/script.ftl
@@ -310,7 +310,7 @@
         // 建站时间统计
         function show_date_time() {
             if ($("#span_dt_dt").length > 0) {
-                window.setTimeout("show_date_time()", 1000);
+                window.setTimeout(show_date_time, 1000);
                 BirthDay = new Date("${settings.TimeStatistics!}");
                 today = new Date();
                 timeold = (today.getTime() - BirthDay.getTime());


### PR DESCRIPTION
### 环境
Windows10 2004 Chrome  85.0.4183.121（正式版本） （64 位）

### 错误描述
浏览器报错`Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed ……`

出错位置：script.ftl

```javascript
window.setTimeout("show_date_time()", 1000);
```

### 错误原因
浏览器安全策略变更导致的错误。

### 修改方式
```javascript
window.setTimeout(show_date_time, 1000);
```